### PR TITLE
Use MacOS native user isolated tmpvar files

### DIFF
--- a/mcwrap.py
+++ b/mcwrap.py
@@ -7,8 +7,9 @@ import glob
 import pathlib
 import logging
 import shutil
+import tempfile
 
-LOG_FILE='/tmp/mcwrap.log'
+LOG_FILE=f'{tempfile.gettempdir()}/mcwrap.log'
 logging.getLogger().addHandler(logging.FileHandler(LOG_FILE))
 
 


### PR DESCRIPTION
Prevents an occasional user permission bug when accessing /tmp
<img width="637" alt="Screen Shot 2021-09-16 at 8 26 00 AM" src="https://user-images.githubusercontent.com/10443116/133612412-1d03efd4-e0b3-403a-8d22-c87a271dda44.png">
